### PR TITLE
fix class name typo

### DIFF
--- a/src/Smoqadam/TelegramCli.php
+++ b/src/Smoqadam/TelegramCli.php
@@ -17,7 +17,7 @@ class TelegramCli
     {
         $this->f = stream_socket_client($socket);
         if ($this->f === false) {
-            throw new Exception('Connect to remote socket failed.');
+            throw new \Exception('Connect to remote socket failed.');
         }
     }
 

--- a/src/Smoqadam/TelegramCli.php
+++ b/src/Smoqadam/TelegramCli.php
@@ -17,7 +17,7 @@ class TelegramCli
     {
         $this->f = stream_socket_client($socket);
         if ($this->f === false) {
-            throw new TException('Connect to remote socket failed.');
+            throw new Exception('Connect to remote socket failed.');
         }
     }
 


### PR DESCRIPTION
AFAIK, we don't have a `TException` class. Do we? If I'm right, this should be a simple typo which you mistyped `Exception`.
